### PR TITLE
Add a Poperties.child() getter for single children

### DIFF
--- a/external/LiveAPI/code/live-api.js
+++ b/external/LiveAPI/code/live-api.js
@@ -204,7 +204,15 @@ function children(args) {
 
 	var nsApi = liveApi(path, objectId);
 
-	var ids = nsApi.get(child);
+    var childId;
+    if (index) {
+        var childPath =
+            nsApi.path.replace(/"/g, "") + " " + child + " " + index;
+        var childApi = liveApi(childPath);
+        childId = ["id", childApi.id];
+    }
+
+    var ids = childId ? childId : nsApi.get(child);
 
 	const data = processChildren(ids, initialProps);
 

--- a/external/LiveAPI/code/live-api.js
+++ b/external/LiveAPI/code/live-api.js
@@ -200,6 +200,7 @@ function children(args) {
 	var objectId = res.objectId;
 	var path = res.path;
 	var child = res.args.child;
+	var index = res.args.index;
 	var initialProps = res.args.initialProps;
 
 	var nsApi = liveApi(path, objectId);

--- a/lib/Properties.ts
+++ b/lib/Properties.ts
@@ -72,7 +72,7 @@ export class Properties<GP, CP, TP, SP, OP> {
 		}
 	}
 
-	async child<TName extends OnlyKeysWithArrayValues<CP>>(child: TName, index:number, childProps?: string[]): Promise<FlatPropertyType<TName, TP, CP>> {
+	async child<TName extends OnlyKeysWithArrayValues<CP>>(child: TName, index:number, childProps?: string[]): Promise<FlatPropertyType<TName, TP, CP> | undefined> {
 		const result = await this.children(child, childProps, index);
 		return (result??[])[0];
 	}

--- a/lib/Properties.ts
+++ b/lib/Properties.ts
@@ -72,7 +72,7 @@ export class Properties<GP, CP, TP, SP, OP> {
 		}
 	}
 
-	async child<TName extends OnlyKeysWithArrayValues<CP>>(child: TName, index:number, childProps?: string[]): Promise<FlatPropertyType<TName, TP, CP> | undefined> {
+	async child<TName extends OnlyKeysWithArrayValues<CP,TP>>(child: TName, index:number, childProps?: string[]): Promise<FlatPropertyType<TName, TP, CP>> {
 		const result = await this.children(child, childProps, index);
 		return (result??[])[0];
 	}
@@ -134,6 +134,12 @@ type FlatPropertyType<TName extends keyof CP, TP, CP> = TName extends keyof TP
 
 type Flatten<T> = T extends Array<infer U> ? Flatten<U> : T;
 
-type OnlyKeysWithArrayValues<T> = {
-	[K in keyof T]: T[K] extends Array<any> ? K : never;
+type OnlyKeysWithArrayValues<T, TLookUp> = {
+    [K in keyof T]: K extends keyof TLookUp
+        ? TLookUp[K] extends Array<any>
+            ? K
+            : never
+        : T[K] extends Array<any>
+        ? K
+        : never;
 }[keyof T];


### PR DESCRIPTION
> This is part of a set of pull requests aimed at reducing the amount of data being transmitted when using this (excellent 🙏) library extensively, often causing me timeouts in high performance situations. I've split my improvements in different features for your convenience, but I'd be happy to help combine them.

This PR adds a `Properties.child(child, index)` getter, mirroring the existing `Properties.children(child)` one:

```typescript
const all = await ({} as Track).children('clip_slots'); // ClipSlot[]
const one = await ({} as Track).child('clip_slots', 1 ); // ClipSlot | undefined
```

It is typed to only work with children marked as an array:
_For determining this, it will look at the transformed property first._
```typescript
await ({} as ClipSlot).children('clip'); // Valid: Clip
await ({} as ClipSlot).child('clip', 1); // Invalid: Already a single child
```

## Example
This will drastically reduce the amount of data transmitted when you know the child index in advance:
```typescript
const track = await live.song.findTrackByName(trackName);
track?.observe('playing_slot_index', async (index) => {
	const launchedClipSlot = await track.child('clip_slots', index);
});
```