### PR TITLE
Give access to the canonical path

### DIFF
--- a/external/LiveAPI/code/live-api.js
+++ b/external/LiveAPI/code/live-api.js
@@ -139,6 +139,7 @@ function getChildProps(childApi, initialProps, childName) {
 
 	const childData = {
 		id: childApi.id,
+        path: childApi.path.replace(/"/g, ""),
 	};
 
 	initialProps.reduce(function(obj, elem) {
@@ -171,6 +172,7 @@ function processChildren(ids, initialProps) {
 
 		var childData = {
 			id: childApi.id,
+            path: childApi.path.replace(/"/g, ""),
 		};
 
 		if (childApi.id === '0') {

--- a/lib/Clip.ts
+++ b/lib/Clip.ts
@@ -446,6 +446,7 @@ export const enum ClipType {
 
 export interface RawClip {
 	id: string;
+	path:string;
 	name: string;
 	length: number;
 	is_audio_clip: boolean;
@@ -491,7 +492,7 @@ export class Clip extends Properties<ClipGetProperties, unknown, unknown, ClipSe
 	 * @memberof Clip
 	 */
 	constructor(ableton: AbletonLive, public raw: RawClip, path?: string) {
-		super(ableton, 'clip', path ? path : Clip.sessionPath);
+		super(ableton, 'clip', path ?? raw.path );
 
 		this._id = parseInt(raw.id, 10);
 		this._name = raw.name;

--- a/lib/ClipSlot.ts
+++ b/lib/ClipSlot.ts
@@ -109,6 +109,7 @@ export interface ObservableProperties {
 
 export interface RawClipSlot {
 	id: number;
+	path: string;
 	has_clip: boolean;
 	clip: RawClip;
 }
@@ -143,7 +144,7 @@ export class ClipSlot extends Properties<
 	 * @memberof ClipSlot
 	 */
 	constructor(ableton: AbletonLive, public raw: RawClipSlot, path?: string) {
-		super(ableton, 'clip_slot', path ? path : ClipSlot.path, initialProperties);
+		super(ableton, 'clip_slot', path ?? raw.path, initialProperties);
 
 		this._id = raw.id;
 		this._hasClip = raw.has_clip;

--- a/lib/Device.ts
+++ b/lib/Device.ts
@@ -80,6 +80,7 @@ export interface DeviceObservableProperties {
 
 export interface RawDevice {
 	id: string;
+	path:string;
 	name: string;
 	type: DeviceType;
 	class_name: string;
@@ -112,7 +113,7 @@ export class Device extends Properties<
 	private _classDisplayName: string;
 
 	constructor(ableton: AbletonLive, public raw: RawDevice, path?: string) {
-		super(ableton, 'device', path ? path : Device.path, initialProps);
+		super(ableton, 'device', path ?? raw.path, initialProps);
 
 		this._id = parseInt(raw.id, 10);
 		this._name = raw.name;

--- a/lib/DeviceParameter.ts
+++ b/lib/DeviceParameter.ts
@@ -106,6 +106,7 @@ export interface DeviceParameterObservableProperties {
 
 export interface RawDeviceParameter {
 	id: number;
+	path:string;
 	name: string;
 	value: number;
 	is_quantized: boolean;
@@ -140,7 +141,7 @@ export class DeviceParameter extends Properties<
 	 * @memberof DeviceParameter
 	 */
 	constructor(ableton: AbletonLive, public raw: RawDeviceParameter, path?: string) {
-		super(ableton, 'device_parameter', path ? path : DeviceParameter.path);
+		super(ableton, 'device_parameter', path ?? raw.path);
 
 		this._id = raw.id;
 

--- a/lib/MixerDevice.ts
+++ b/lib/MixerDevice.ts
@@ -86,6 +86,7 @@ export interface MixerDeviceObservableProperties {
 
 export interface RawMixerDevice {
 	id: number;
+	path:string;
 	volume: RawDeviceParameter;
 	panning: RawDeviceParameter;
 }
@@ -121,7 +122,7 @@ export class MixerDevice extends Properties<
 	private _panning: DeviceParameter;
 
 	constructor(ableton: AbletonLive, public raw: RawMixerDevice, path?: string) {
-		super(ableton, 'mixer_device', path ? path : MixerDevice.path, childrenInitialProps);
+		super(ableton, 'mixer_device', path ?? raw.path, childrenInitialProps);
 
 		this._id = raw.id;
 		this._volume = new DeviceParameter(this.ableton, raw.volume);

--- a/lib/Properties.ts
+++ b/lib/Properties.ts
@@ -12,13 +12,17 @@ export class Properties<GP, CP, TP, SP, OP> {
 	constructor(
 		protected ableton: AbletonLive,
 		protected ns: string,
-		protected path: string,
+		protected _path: string,
 		protected childrenInitialProps?: Partial<{ [T in keyof CP]: (string | ChildrenInitialProps)[] }>,
 		protected _id?: number
 	) {}
 
 	get id(): number | undefined {
 		return this._id;
+	}
+
+	get path():string {
+		return this._path;
 	}
 
 	/**

--- a/lib/Scene.ts
+++ b/lib/Scene.ts
@@ -98,6 +98,7 @@ export interface SceneObservableProperties {
 
 export interface RawScene {
 	id: string;
+	path:string;
 	name: string;
 	isEmpty: boolean;
 }
@@ -141,7 +142,7 @@ export class Scene extends Properties<
 	 * @memberof Scene
 	 */
 	constructor(ableton: AbletonLive, public raw: RawScene, path?: string) {
-		super(ableton, 'scene', path ? path : Scene.path, childrenInitialProps);
+		super(ableton, 'scene', path ?? raw.path, childrenInitialProps);
 
 		this._id = parseInt(raw.id, 10);
 		this._name = raw.name;

--- a/lib/Track.ts
+++ b/lib/Track.ts
@@ -396,6 +396,7 @@ export type TrackRoutingType = { display_name: string; identifier: number };
  */
 export interface RawTrack {
 	id: string;
+	path:string;
 	name: string;
 	has_audio_input: boolean;
 }
@@ -461,7 +462,7 @@ export class Track extends Properties<
 	 * @memberof Track
 	 */
 	constructor(ableton: AbletonLive, public raw: RawTrack, path?: string) {
-		super(ableton, 'track', path ? path : Track.path, childrenInitialProps);
+		super(ableton, 'track', path ?? raw.path, childrenInitialProps);
 
 		this._id = parseInt(raw.id, 10);
 		this._name = raw.name;


### PR DESCRIPTION
> This is part of a set of pull requests aimed at reducing the amount of data being transmitted when using this (excellent 🙏) library extensively, often causing me timeouts in high performance situations. I've split my improvements in different features for your convenience, but I'd be happy to help combine them.

This PR adds a getter for the canonical path of retrieved objects:
```typescript
track.path; // live_set tracks 4
```
This opens up the possibility to retrieve the index of an object, and query more effectively.
## Example
_This example uses my first PR #18 for adding a single child getter._
```typescript
async function getClipSlotFromSelectedSceneOnTrack(trackName: string) {
	const selectedScene = await live.songView.children('selected_scene');
	const selectedSceneIndex = Number(selectedScene.path.split(' ').pop());
	const track = await findTrackByName(trackName);
	const clipSlot = track?.child('clip_slots', selectedSceneIndex);
	return clipSlot;
}
```