### PR TITLE
Add typings for argument childProps in Properties.children()

### DIFF
--- a/lib/Properties.ts
+++ b/lib/Properties.ts
@@ -50,7 +50,7 @@ export class Properties<GP, CP, TP, SP, OP> {
 		return value;
 	}
 
-	async children<T extends keyof CP>(child: T, childProps?: string[]): Promise<T extends keyof TP ? TP[T] : CP[T]> {
+	async children<TName extends keyof CP>(child: TName, childProps?: InitialProps<TName,CP, TP>[]): Promise<PropertyType<TName,TP,CP>> {
 		let initialProps;
 
 		if (this.childrenInitialProps) {
@@ -118,3 +118,42 @@ export class Properties<GP, CP, TP, SP, OP> {
 		return this.ableton.callMultiple(this.path, calls, this._id, timeout);
 	}
 }
+
+type InitialProps<TName extends keyof CP, CP, TP> =
+	| ChildProps<TName, CP, TP>
+	| ChildChildren<TName, CP, TP>;
+
+type ChildProps<TName extends keyof CP, CP, TP> = FlatPropertyType<
+	TName,
+	TP,
+	CP
+> extends Properties<infer GP, any, any, any, any>
+	? keyof GP
+	: never;
+
+type ChildChildren<TName extends keyof CP, CP, TP> = FlatPropertyType<
+	TName,
+	TP,
+	CP
+> extends Properties<any, infer _CP, infer _TP, any, any>
+	? ChildChildrenDescriptor<_CP, _TP, keyof _CP>
+	: FlatPropertyType<
+		TName,
+		TP,
+		CP
+	>;
+
+type ChildChildrenDescriptor<_CP, _TP, TName extends keyof _CP = any> = {
+	name: TName;
+	initialProps: InitialProps<TName, _CP, _TP>[];
+};
+
+type PropertyType<TName extends keyof CP, TP, CP> = TName extends keyof TP
+	? TP[TName]
+	: CP[TName];
+	
+type FlatPropertyType<TName extends keyof CP, TP, CP> = TName extends keyof TP
+	? Flatten<TP[TName]>
+	: Flatten<CP[TName]>;
+
+type Flatten<T> = T extends Array<infer U> ? Flatten<U> : T;


### PR DESCRIPTION
> This is part of a set of pull requests aimed at reducing the amount of data being transmitted when using this (excellent 🙏) library extensively, often causing me timeouts in high performance situations. I've split my improvements in different features for your convenience, but I'd be happy to help combine them.

This PR is a first attempt at typing the `childProps` argument in `Properties.children()`.
```typescript
live.song.children('tracks', ['name', 'current_monitoring_state']);
// The property array is typed and has autocompletion for all property names present on the raw entry
```
It even includes rudimentary autocompletion for nesting children:
```typescript
({} as Track).children('clip_slots', ['has_stop_button', 'will_record_on_start']);
({} as Track).children('clip_slots', ['playing_status', {name:'clip', initialProps:['legato']}]);
```
I haven't managed to get autocompletion working when the nested child is an array type though:
```typescript
({} as Song).children('tracks', ['has_midi_input', {name:'clip_slots', initialProps:[/* Nothing here unfortunately, as clip_slots is an array property */]}]);
```
Once this bug is ironed out of the type definitions, you should be able to recursively select anything you want in one query (as far as I could tell the js on the M4L side already supports nesting). 